### PR TITLE
Make all area of the .nav-vertical items clickable

### DIFF
--- a/scss/objects/_navigation.scss
+++ b/scss/objects/_navigation.scss
@@ -228,7 +228,11 @@
     li {
       display: block;
       margin-right: 0px;
-      padding: 10px;
+
+      a {
+        display: block;
+        padding: 10px;
+      }
     }
     
     .icon {


### PR DESCRIPTION
Currently, the .nav-vertical items will only follow the link if the
user clicks directly on the text.  I added this little bit that works
for my case.  Might not work in all cases, but is handy when you have
<a> tags in your <li> tags.
