### PR TITLE
ignore Gulpfile.js, but not LICENSE

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,9 +4,9 @@
   "version": "2.0.0",
   "ignore": [
     ".gitignore",
-    "LICENSE",
     "README.md",
-    "package.json"
+    "package.json",
+    "Gulpfile.js"
   ],
   "keywords": [
     "css",


### PR DESCRIPTION
Either ignore `Gulpfile.js`, or don't ignore `package.json` since one won't make sense without the other :)  Also, when I `bower install` this into a project at work, the LICENSE file would be a useful reference.
