### PR TITLE
Move order of $base-unit

### DIFF
--- a/src/custom/_globals.scss
+++ b/src/custom/_globals.scss
@@ -17,20 +17,15 @@
 // $bp-large:       70em;
 // $bp-extra-large: 80em;
 
+// Base Size (used in unitSize() for proportions)
+// $base-unit: 8;
+
 // Spacing
 // $spacing-xs: unitSize(1);
 // $spacing-s:  unitSize(2);
 // $spacing-m:  unitSize(3);
 // $spacing-l:  unitSize(4);
 // $spacing-xl: unitSize(5);
-
-
-//
-// Base Size
-// ---------
-// Allows sizes in proportions
-
-// $base-unit: 8;
 
 
 //


### PR DESCRIPTION
Fix a problem with the spacing variables, omiting the value of $base-unit.