### PR TITLE
Enhance the experience when using diamond

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ concisecss compile input.scss output.css
 
 **Note**: When compiling the source code with the Concise CLI, Autoprefixer will automatically add the required browser prefixes for the last two browser versions.
 
+### Building with diamond
+To build with diamond, simply use the `diamond compile` command. If you are new to diamond, you can check their [documentation](https://diamond.js.org/docs).  
+
+```
+diamond compile -o output.css input.scss
+```
+
 ### Changelog
 
 You can keep up-to-date with the changes that we have made via our [releases page](https://github.com/ConciseCSS/concise.css/releases).

--- a/diamond.js
+++ b/diamond.js
@@ -1,0 +1,11 @@
+const postcss = require('postcss');
+
+module.exports = (css) => {
+  return postcss([
+    require('postcss-input-range'),
+    require('postcss-lh'),
+    require('postcss-custom-media'),
+    require('postcss-media-minmax'),
+    require('autoprefixer')
+  ]).process(css).css;
+};

--- a/package.json
+++ b/package.json
@@ -31,7 +31,12 @@
     "http-server": "^0.9.0",
     "jake": "^8.0.15",
     "livereload": "^0.6.0",
-    "stylestats": "^6.3.0"
+    "stylestats": "^6.3.0",
+    "postcss": "^5.0.21",
+    "postcss-custom-media": "^5.0.1",
+    "postcss-lh": "^1.1.0",
+    "postcss-media-minmax": "^2.1.2",
+    "postcss-input-range": "^2.0.0"
   },
   "scripts": {
     "build": "jake build",
@@ -40,6 +45,7 @@
     "stats:min": "stylestats dist/concise.min.css"
   },
   "diamond": {
-    "main": "concise.scss" 
+    "main": "concise.scss",
+    "postCompile": "diamond.js"
   }
 }


### PR DESCRIPTION
This is a follow up to #263

This adds the functions done in the `compile-cli` to a post-compile script for diamond to use while compiling.

`diamond compile -o output.css input.scss` would automatically run all of the required PostCSS stuff.

I can change filenames or do anything if needed. (Note: PostCSS deps can be moved to devDependencies)